### PR TITLE
Added support for boot disk and static external IP

### DIFF
--- a/.pangaea
+++ b/.pangaea
@@ -12,7 +12,6 @@ LOGROTATE_DOCKER=false
 GCE_INSTANCE_NAME=testin
 GCE_MACHINE_TYPE=n1-standard-1
 GCE_BOOT_DISK=disk-name
-GCE_EXT_IP=ext-ip-address
 GCE_EXT_IP_NAME=ext-ip-address-name
 # Optional
 GCE_DISK_MOUNTS=(

--- a/.pangaea
+++ b/.pangaea
@@ -8,7 +8,13 @@ PROVIDER=gce
 LOGROTATE_DOCKER=false
 
 # GCE
+# Required
 GCE_INSTANCE_NAME=testin
+GCE_MACHINE_TYPE=n1-standard-1
+GCE_BOOT_DISK=disk-name
+GCE_EXT_IP=ext-ip-address
+GCE_EXT_IP_NAME=ext-ip-address-name
+# Optional
 GCE_DISK_MOUNTS=(
 #   diskname mountpath
 )

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pangaea/bin/vagrant halt  # Bring down node
 
 In `.pangaea`  
 Set `PROVIDER=gce`  
-Set `GCE_INSTANCE_NAME` to the name of the compute resource you want to create
+Set `GCE_INSTANCE_NAME` to the name of the compute resource you want to create  
 Set `GCE_MACHINE_TYPE` to the required type, default is `n1-standard-1`
 
 ```bash
@@ -73,13 +73,12 @@ gcloud compute disks create disk-name --image coreos
 
 # Create an External IP address for the project
 gcloud compute addresses create ext-ip-address-name
-# Note down the name and ip address, to add it to .pangaea 
+# Note down the name, to add it to .pangaea 
 
 # Edit .pangaea to include these variables
 vim .pangaea
 # ...
 GCE_BOOT_DISK=disk-name
-GCE_EXT_IP=ext-ip-address
 GCE_EXT_IP_NAME=ext-ip-address-name
 # ...
 

--- a/README.md
+++ b/README.md
@@ -59,35 +59,41 @@ pangaea/bin/vagrant halt  # Bring down node
 In `.pangaea`  
 Set `PROVIDER=gce`  
 Set `GCE_INSTANCE_NAME` to the name of the compute resource you want to create
+Set `GCE_MACHINE_TYPE` to the required type, default is `n1-standard-1`
 
 ```bash
-# First, set up the GCE project and zone
+# First, set up the GCE project, region and zone
 gcloud auth login
 gcloud config set project sample-project
+gcloud config set compute/region asia-east1
 gcloud config set compute/zone asia-east1-a
 
 # Create a GCE boot disk with CoreOS image
 gcloud compute disks create disk-name --image coreos
-# Edit .pangaea to include this boot disk in variable GCE_BOOT_DISK_MOUNTS
+
+# Create an External IP address for the project
+gcloud compute addresses create ext-ip-address-name
+# Note down the name and ip address, to add it to .pangaea 
+
+# Edit .pangaea to include these variables
 vim .pangaea
 # ...
-GCE_BOOT_DISK_MOUNTS=(
-    disk-name /
-)
+GCE_BOOT_DISK=disk-name
+GCE_EXT_IP=ext-ip-address
+GCE_EXT_IP_NAME=ext-ip-address-name
 # ...
 
-pangaea/gce/up.sh setup # Creates a GCE based Kubernetes node with the boot disk, create and attach a static external IP to it.
+pangaea/gce/up.sh init # Creates a GCE based Kubernetes node with the boot disk, attach the static external IP to it.
 # Provisions the Kubernetes node
 # Opens the firewall to the secure endpoint of the Kubernetes API server
 # Sets up local kubectl to work with the Kubernetes node
 
 kubectl get po       # Working Kubernetes
 
-pangaea/gce/down.sh  # Destroys the compute instance, and deletes the firewall entry, but IP is still reserved.
+pangaea/gce/down.sh  # Destroys the compute instance, and deletes the firewall entry, but IP is still reserved, disk is also persisted.
 
 pangaea/gce/up.sh    # Creates a new VM and attach the same boot disk, same IP, so that state is preserved.
 
-pangaea/gce/down.sh setup # Destroys the VM, firewall and reserved static IP. Will have to use a fresh boot disk now.
 ```
 
 Share the folder named after your instance under `pangaea/pki/keys` with your team and have them run `pangaea/bin/kubectl_setup` to config their workstation kubectl to work with the GCE instance.

--- a/README.md
+++ b/README.md
@@ -66,14 +66,28 @@ gcloud auth login
 gcloud config set project sample-project
 gcloud config set compute/zone asia-east1-a
 
-pangaea/gce/up.sh    # Creates a GCE based Kubernetes node
+# Create a GCE boot disk with CoreOS image
+gcloud compute disks create disk-name --image coreos
+# Edit .pangaea to include this boot disk in variable GCE_BOOT_DISK_MOUNTS
+vim .pangaea
+# ...
+GCE_BOOT_DISK_MOUNTS=(
+    disk-name /
+)
+# ...
+
+pangaea/gce/up.sh setup # Creates a GCE based Kubernetes node with the boot disk, create and attach a static external IP to it.
 # Provisions the Kubernetes node
 # Opens the firewall to the secure endpoint of the Kubernetes API server
 # Sets up local kubectl to work with the Kubernetes node
 
 kubectl get po       # Working Kubernetes
 
-pangaea/gce/down.sh  # Destroys the compute instance, and deletes the firewall entry
+pangaea/gce/down.sh  # Destroys the compute instance, and deletes the firewall entry, but IP is still reserved.
+
+pangaea/gce/up.sh    # Creates a new VM and attach the same boot disk, same IP, so that state is preserved.
+
+pangaea/gce/down.sh setup # Destroys the VM, firewall and reserved static IP. Will have to use a fresh boot disk now.
 ```
 
 Share the folder named after your instance under `pangaea/pki/keys` with your team and have them run `pangaea/bin/kubectl_setup` to config their workstation kubectl to work with the GCE instance.

--- a/pangaea/docs/workflow.md
+++ b/pangaea/docs/workflow.md
@@ -302,6 +302,24 @@ GCE_DISK_MOUNTS=(
 - `gcloud compute instances attach-disk name-of-instance --disk disk-name`
 - Create/upgrade the instance
 
+### Mounting GCE Boot disks
+
+A persistant disk can be used as the root filesystem so that the kubernetes state is preserved when the machine is restarted.
+
+- Create the GCE boot disk with a CoreOS image
+- `gcloud compute disks create disk-name --image coreos`
+- Edit .pangaea to include this boot disk in variable GCE_BOOT_DISK_MOUNTS
+- vim .pangaea
+```shell
+# ...
+GCE_BOOT_DISK_MOUNTS=(
+    disk-name /
+)
+# ...
+```
+- The disk will be mounted when `pangaea/gce/up.sh` is run and the machine boots from the disk.
+- When the VM is destroyed, the disk will be preserved
+
 ### Forward Docker and systemd Logs
 
 - set LOGROTATE_DOCKER to true in .pangaea

--- a/pangaea/docs/workflow.md
+++ b/pangaea/docs/workflow.md
@@ -308,13 +308,11 @@ A persistant disk can be used as the root filesystem so that the kubernetes stat
 
 - Create the GCE boot disk with a CoreOS image
 - `gcloud compute disks create disk-name --image coreos`
-- Edit .pangaea to include this boot disk in variable GCE_BOOT_DISK_MOUNTS
+- Edit .pangaea to include this boot disk in variable GCE_BOOT_DISK
 - vim .pangaea
 ```shell
 # ...
-GCE_BOOT_DISK_MOUNTS=(
-    disk-name /
-)
+GCE_BOOT_DISK_MOUNTS=disk-name
 # ...
 ```
 - The disk will be mounted when `pangaea/gce/up.sh` is run and the machine boots from the disk.

--- a/pangaea/docs/workflow.md
+++ b/pangaea/docs/workflow.md
@@ -262,7 +262,7 @@ In production we want to run fully self contained containers so that we have an 
 - The `init` subcommand is important when it the first boot after the boot disk has been created.
     - It creates the required certificates and keys and set them up both on server and client.
     - `init` has to be run only once. Subsequent runs can use `gce/up.sh` and `gce/down.sh` as it is.
-    - Please note that if `init` has been run on the same disk twice, the authentication will fail.
+    - Please note that if `init` has been run on the same disk more than once, the kubernetes API authentication with GCE instance will fail.
 - kubectl has been configured to work with the GCE instance by the above script, let's use it to wait until the node is ready
 - `watch -n1 kubectl get po --namespace=kube-system`
 - Wait until all five pods are ready

--- a/pangaea/gce/down.sh
+++ b/pangaea/gce/down.sh
@@ -5,8 +5,6 @@ set -e
 SCRIPT_DIR=`dirname $0`
 ROOT_DIR=$SCRIPT_DIR/../..
 
-COMMAND=$1
-
 source $ROOT_DIR/.pangaea
 
 gcloud compute instances delete "$GCE_INSTANCE_NAME" -q

--- a/pangaea/gce/down.sh
+++ b/pangaea/gce/down.sh
@@ -5,7 +5,6 @@ set -e
 SCRIPT_DIR=`dirname $0`
 ROOT_DIR=$SCRIPT_DIR/../..
 
-EXT_IP_CREATED_JSON=$ROOT_DIR/.tmp/gce_ext_ip_create.json
 COMMAND=$1
 
 source $ROOT_DIR/.pangaea

--- a/pangaea/gce/down.sh
+++ b/pangaea/gce/down.sh
@@ -5,8 +5,17 @@ set -e
 SCRIPT_DIR=`dirname $0`
 ROOT_DIR=$SCRIPT_DIR/../..
 
+EXT_IP_CREATED_JSON=$ROOT_DIR/.tmp/gce_ext_ip_create.json
+COMMAND=$1
+
 source $ROOT_DIR/.pangaea
 
 gcloud compute instances delete "$GCE_INSTANCE_NAME" -q
 
 gcloud compute firewall-rules delete "$GCE_INSTANCE_NAME-kubeapiserver-443" -q || true
+
+if [ "$COMMAND" = "setup" ]
+    then
+	gcloud compute addresses delete "${GCE_INSTANCE_NAME}-ext-ip" --region asia-east1 -q 
+	rm $EXT_IP_CREATED_JSON
+fi

--- a/pangaea/gce/down.sh
+++ b/pangaea/gce/down.sh
@@ -13,9 +13,3 @@ source $ROOT_DIR/.pangaea
 gcloud compute instances delete "$GCE_INSTANCE_NAME" -q
 
 gcloud compute firewall-rules delete "$GCE_INSTANCE_NAME-kubeapiserver-443" -q || true
-
-if [ "$COMMAND" = "setup" ]
-    then
-	gcloud compute addresses delete "${GCE_INSTANCE_NAME}-ext-ip" --region asia-east1 -q 
-	rm $EXT_IP_CREATED_JSON
-fi

--- a/pangaea/gce/up.sh
+++ b/pangaea/gce/up.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR=$(dirname $0)
 ROOT_DIR=$SCRIPT_DIR/../..
 
 COMMAND=$1
+
 # ENSURE CORRECT PROVIDER
 
 source "$ROOT_DIR/.pangaea"
@@ -20,9 +21,6 @@ fi
 CLOUD_CONFIG=$ROOT_DIR/pangaea/kubernetes/cloud-config.sh
 
 CREATED_JSON=$ROOT_DIR/.tmp/gce_instance_create.json
-EXT_IP_CREATED_JSON=$ROOT_DIR/.tmp/gce_ext_ip_create.json
-
-EXT_IP=""
 
 GCE_DISK_ARGS=""
 function generate_gce_disk_args {
@@ -33,85 +31,46 @@ function generate_gce_disk_args {
 }
 generate_gce_disk_args "${GCE_DISK_MOUNTS[@]}"
 
-GCE_BOOT_DISK_ARGS=""
-function generate_gce_boot_disk_args {
-    while [ ! $# -eq 0 ]; do
-        GCE_BOOT_DISK_ARGS="$GCE_BOOT_DISK_ARGS --disk name=$1,device-name=$1,boot=yes,auto-delete=no,mode=rw"
-        shift 2
-    done
-}
-generate_gce_boot_disk_args "${GCE_BOOT_DISK_MOUNTS[@]}"
-
-if [ "$COMMAND" = "setup" ]
-    then
-	gcloud compute addresses create ${GCE_INSTANCE_NAME}-ext-ip --format json --region asia-east1 > "$EXT_IP_CREATED_JSON"	
-    else
-	if [ ! -f $EXT_IP_CREATED_JSON ]; then
-	    echo "PAN: External IP address not created! Please run with 'setup' argument."
-	    exit 1
-	fi
-fi
-
-EXT_IP=$(cat "$EXT_IP_CREATED_JSON" | jq -r '.[0].address')
+GCE_BOOT_DISK_ARGS="--disk name=$GCE_BOOT_DISK,device-name=$GCE_BOOT_DISK,boot=yes,auto-delete=no,mode=rw"
 
 gcloud compute instances create $GCE_INSTANCE_NAME \
 \
-    --machine-type n1-standard-1 \
+    --machine-type $GCE_MACHINE_TYPE\
     $GCE_BOOT_DISK_ARGS \
     $GCE_DISK_ARGS \
-    --address "${GCE_INSTANCE_NAME}-ext-ip" \
+    --address $GCE_EXT_IP_NAME \
     --metadata-from-file user-data="$CLOUD_CONFIG" \
     --scopes https://www.googleapis.com/auth/cloud.useraccounts.readonly,https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/compute \
     --format json > "$CREATED_JSON"
 
 
+NODE_IP=$(cat "$CREATED_JSON" | jq -r '.[0].networkInterfaces[0].accessConfigs[0].natIP')
+
 function init_ssl_and_setup_archive {
-    local NODE_IP=$(cat "$CREATED_JSON" | jq -r '.[0].networkInterfaces[0].accessConfigs[0].natIP')
 
     local SETUP_TAR=$ROOT_DIR/.tmp/setup.tar # written to by init script
     local SETUP_MD5=$ROOT_DIR/.tmp/setup.md5
     "$ROOT_DIR/pangaea/setup/init_ssl_and_setup_archive.sh" create $GCE_INSTANCE_NAME $NODE_IP
 
-
     gcloud compute copy-files "$SETUP_TAR" "core@$GCE_INSTANCE_NAME:/tmp/setup.tar"
     gcloud compute copy-files "$SETUP_MD5" "core@$GCE_INSTANCE_NAME:/tmp/setup.md5"
 }
 
-SSH_LIVE=0
-
-function check_ssh {
-    gcloud compute ssh core@$GCE_INSTANCE_NAME --ssh-flag="-q" --ssh-flag="-o BatchMode=yes" --ssh-flag="-o ConnectTimeout=10" exit
-    if [ $? -eq 0 ]
-    then
-        echo 'can connect'
-        SSH_LIVE=1
-    else
-        echo 'cannot connect'
-        SSH_LIVE=0
-    fi
-}
-
-check_ssh
-
 SSH_RETRIES=0
 
-while [ $SSH_LIVE -ne 1 ]
-do
-    if [ $SSH_RETRIES -gt 5 ]
-    then
-        echo 'SSH retries failed. Deleting VM and exiting'
+while ! gcloud compute ssh core@$GCE_INSTANCE_NAME --command 'date' &>/dev/null; do
+    if [ $SSH_RETRIES -gt 5 ]; then
+        echo 'SSH retries failed. Error occured within VM. Deleting VM and exiting'
         gcloud compute instances delete $GCE_INSTANCE_NAME -q
         exit
     fi  
-    check_ssh
     sleep 10
     SSH_RETRIES=$((SSH_RETRIES+1))
 done
 
 
-if [ "$COMMAND" = "setup" ] 
-    then
-	init_ssl_and_setup_archive
+if [ "$COMMAND" = "init" ]; then
+    init_ssl_and_setup_archive
 fi
 
 gcloud compute firewall-rules create "$GCE_INSTANCE_NAME-kubeapiserver-443" --allow tcp:443 --description "$GCE_INSTANCE_NAME: kubernetes api server secure port"
@@ -123,7 +82,7 @@ echo "###############################################"
 echo
 echo "The Kubernetes compute instance is now booting."
 echo "gcloud compute ssh core@$GCE_INSTANCE_NAME"
-echo "External IP address is $EXT_IP"
+echo "External IP address is $NODE_IP"
 echo
 echo "###############################################"
 echo

--- a/pangaea/gce/up.sh
+++ b/pangaea/gce/up.sh
@@ -31,7 +31,7 @@ function generate_gce_disk_args {
 }
 generate_gce_disk_args "${GCE_DISK_MOUNTS[@]}"
 
-GCE_BOOT_DISK_ARGS="--disk name=$GCE_BOOT_DISK,device-name=$GCE_BOOT_DISK,boot=yes,auto-delete=no,mode=rw"
+GCE_BOOT_DISK_ARGS="--disk name=$GCE_BOOT_DISK,boot=yes,auto-delete=no,mode=rw"
 
 gcloud compute instances create $GCE_INSTANCE_NAME \
 \

--- a/pangaea/gce/up.sh
+++ b/pangaea/gce/up.sh
@@ -5,6 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ROOT_DIR=$SCRIPT_DIR/../..
 
+COMMAND=$1
 # ENSURE CORRECT PROVIDER
 
 source "$ROOT_DIR/.pangaea"
@@ -19,6 +20,9 @@ fi
 CLOUD_CONFIG=$ROOT_DIR/pangaea/kubernetes/cloud-config.sh
 
 CREATED_JSON=$ROOT_DIR/.tmp/gce_instance_create.json
+EXT_IP_CREATED_JSON=$ROOT_DIR/.tmp/gce_ext_ip_create.json
+
+EXT_IP=""
 
 GCE_DISK_ARGS=""
 function generate_gce_disk_args {
@@ -29,17 +33,37 @@ function generate_gce_disk_args {
 }
 generate_gce_disk_args "${GCE_DISK_MOUNTS[@]}"
 
+GCE_BOOT_DISK_ARGS=""
+function generate_gce_boot_disk_args {
+    while [ ! $# -eq 0 ]; do
+        GCE_BOOT_DISK_ARGS="$GCE_BOOT_DISK_ARGS --disk name=$1,device-name=$1,boot=yes,auto-delete=no,mode=rw"
+        shift 2
+    done
+}
+generate_gce_boot_disk_args "${GCE_BOOT_DISK_MOUNTS[@]}"
+
+if [ "$COMMAND" = "setup" ]
+    then
+	gcloud compute addresses create ${GCE_INSTANCE_NAME}-ext-ip --format json --region asia-east1 > "$EXT_IP_CREATED_JSON"	
+    else
+	if [ ! -f $EXT_IP_CREATED_JSON ]; then
+	    echo "PAN: External IP address not created! Please run with 'setup' argument."
+	    exit 1
+	fi
+fi
+
+EXT_IP=$(cat "$EXT_IP_CREATED_JSON" | jq -r '.[0].address')
+
 gcloud compute instances create $GCE_INSTANCE_NAME \
 \
-    --machine-type n1-standard-2 \
-    --boot-disk-size 20GB \
-    --boot-disk-type pd-ssd \
-\
+    --machine-type n1-standard-1 \
+    $GCE_BOOT_DISK_ARGS \
     $GCE_DISK_ARGS \
-    --image coreos \
+    --address "${GCE_INSTANCE_NAME}-ext-ip" \
     --metadata-from-file user-data="$CLOUD_CONFIG" \
     --scopes https://www.googleapis.com/auth/cloud.useraccounts.readonly,https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/compute \
     --format json > "$CREATED_JSON"
+
 
 function init_ssl_and_setup_archive {
     local NODE_IP=$(cat "$CREATED_JSON" | jq -r '.[0].networkInterfaces[0].accessConfigs[0].natIP')
@@ -48,10 +72,47 @@ function init_ssl_and_setup_archive {
     local SETUP_MD5=$ROOT_DIR/.tmp/setup.md5
     "$ROOT_DIR/pangaea/setup/init_ssl_and_setup_archive.sh" create $GCE_INSTANCE_NAME $NODE_IP
 
-    gcloud compute copy-files "$SETUP_TAR" "$GCE_INSTANCE_NAME:/tmp/setup.tar"
-    gcloud compute copy-files "$SETUP_MD5" "$GCE_INSTANCE_NAME:/tmp/setup.md5"
+
+    gcloud compute copy-files "$SETUP_TAR" "core@$GCE_INSTANCE_NAME:/tmp/setup.tar"
+    gcloud compute copy-files "$SETUP_MD5" "core@$GCE_INSTANCE_NAME:/tmp/setup.md5"
 }
-init_ssl_and_setup_archive
+
+SSH_LIVE=0
+
+function check_ssh {
+    gcloud compute ssh core@$GCE_INSTANCE_NAME --ssh-flag="-q" --ssh-flag="-o BatchMode=yes" --ssh-flag="-o ConnectTimeout=10" exit
+    if [ $? -eq 0 ]
+    then
+        echo 'can connect'
+        SSH_LIVE=1
+    else
+        echo 'cannot connect'
+        SSH_LIVE=0
+    fi
+}
+
+check_ssh
+
+SSH_RETRIES=0
+
+while [ $SSH_LIVE -ne 1 ]
+do
+    if [ $SSH_RETRIES -gt 5 ]
+    then
+        echo 'SSH retries failed. Deleting VM and exiting'
+        gcloud compute instances delete $GCE_INSTANCE_NAME -q
+        exit
+    fi  
+    check_ssh
+    sleep 10
+    SSH_RETRIES=$((SSH_RETRIES+1))
+done
+
+
+if [ "$COMMAND" = "setup" ] 
+    then
+	init_ssl_and_setup_archive
+fi
 
 gcloud compute firewall-rules create "$GCE_INSTANCE_NAME-kubeapiserver-443" --allow tcp:443 --description "$GCE_INSTANCE_NAME: kubernetes api server secure port"
 
@@ -62,6 +123,7 @@ echo "###############################################"
 echo
 echo "The Kubernetes compute instance is now booting."
 echo "gcloud compute ssh core@$GCE_INSTANCE_NAME"
+echo "External IP address is $EXT_IP"
 echo
 echo "###############################################"
 echo


### PR DESCRIPTION
Modified `pangaea/gce/up.sh` to support boot persistent disk and reserving a static external IP address. Can delete the VM, resize/scale it and bring it back again, but the boot persistent disk will preserve the state.